### PR TITLE
0.6 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ Pressing enter on a search result takes you to that page in Notion in your defau
 
 Hold Cmd + press enter on any search result to copy the url to your clipboard. 
 
-Comes with pre-configured support for [OneUpdater](https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater) for automatic version updates.
+**Additional features**
 
-The workflow also provides the ability to quickly see your __recently viewed pages__. Simply type the 'ns' keyword to start the workflow, as you would before you search, and your most recently viewed notion pages are displayed. 
+* Comes with pre-configured support for [OneUpdater](https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater) for automatic version updates.
+
+* The workflow also provides the ability to quickly see your __recently viewed pages__. Simply type the 'ns' keyword to start the workflow, as you would before you search, and your most recently viewed notion pages are displayed. 
+
+* Open a new notion page by typing 'nsn', this only supports the web app currently, it's very handy!
 
 ![img](https://raw.githubusercontent.com/wrjlewis/notion-search-alfred5-workflow/main/alfred%20notion%20search.gif)
 
@@ -59,7 +63,17 @@ Install cairosvgs's dependency, cairo. With [Homebrew](https://brew.sh/) for exa
 
 `brew install cairo`
 
-If you haven't used homebrew before, you may want to skip this optional step.
+If you haven't used homebrew before, you may want to skip this optional step or install homebrew (easy with a quick google search).
+
+UPDATE: There seems to be an issue with cairosvg on apple silicon, use this fix at your own risk but this worked for me and now SVG icons show again:
+
+```
+brew install cairo pango gdk-pixbuf libxml2 libxslt libffi
+sudo mkdir /usr/local/lib/
+sudo ln -s /opt/homebrew/lib/libcairo-2.dll /usr/local/lib/libcairo-2.dll
+sudo ln -s /opt/homebrew/lib/libcairo.so.2 /usr/local/lib/libcairo.so.2
+sudo ln -s /opt/homebrew/lib/libcairo.2.dylib /usr/local/lib/libcairo.2.dylib
+```
 
 ### Get your workflow variables
 

--- a/info.plist
+++ b/info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>bundleid</key>
 	<string>com.wrjlewis.notion-search</string>
-	<key>category</key>
-	<string>Productivity</string>
 	<key>connections</key>
 	<dict>
 		<key>7DD3BDE5-A157-42E5-9376-F681FB50A4EE</key>
@@ -37,6 +35,19 @@
 				<integer>1048576</integer>
 				<key>modifiersubtext</key>
 				<string>Copy to clipboard</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
+		<key>8083D292-1994-456E-AC9C-CCCFDDA3EF47</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>9C705833-7A87-43F9-8C8F-2485909F2D6A</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
 				<key>vitoclose</key>
 				<false/>
 			</dict>
@@ -240,9 +251,63 @@ fi</string>
 			<key>version</key>
 			<integer>3</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>browser</key>
+				<string></string>
+				<key>skipqueryencode</key>
+				<false/>
+				<key>skipvarencode</key>
+				<false/>
+				<key>spaces</key>
+				<string></string>
+				<key>url</key>
+				<string>https://notion.new</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.openurl</string>
+			<key>uid</key>
+			<string>9C705833-7A87-43F9-8C8F-2485909F2D6A</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argumenttype</key>
+				<integer>2</integer>
+				<key>keyword</key>
+				<string>nsn</string>
+				<key>subtext</key>
+				<string></string>
+				<key>text</key>
+				<string>Open a new page in Notion..</string>
+				<key>withspace</key>
+				<false/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.keyword</string>
+			<key>uid</key>
+			<string>8083D292-1994-456E-AC9C-CCCFDDA3EF47</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
 	</array>
 	<key>readme</key>
-	<string>notion-search-alfred-workflow
+	<string>New in 0.6:
+
+- Type ‘nsn’ for the option to quickly open a new page in Notion. Very handy! (Only supports the web app currently)
+
+- https://github.com/wrjlewis/notion-search-alfred-workflow/issues/83 - Fixed a bug that would cause an error and no more results to be displayed, relating to new Notion projects and icons.
+
+- I've added new cairo (SVG icons) instructions for those on apple silicon, to the readme at the projects github page, use at your own risk but they work for me and svg icons now appear in search results.
+
+https://github.com/wrjlewis/notion-search-alfred5-workflow/
+
+--
+
+notion-search-alfred-workflow
 An Alfred workflow to search Notion.so with instant results
 
 Simply type your keyword into Alfred (default: ns) to see instant search results from Notion that mimic the Quick Find function in the Notion webapp. Selecting a search result takes you to that page in Notion in your default web browser.
@@ -269,6 +334,20 @@ Thanks!</string>
 			<real>30</real>
 			<key>ypos</key>
 			<real>100</real>
+		</dict>
+		<key>8083D292-1994-456E-AC9C-CCCFDDA3EF47</key>
+		<dict>
+			<key>xpos</key>
+			<real>65</real>
+			<key>ypos</key>
+			<real>485</real>
+		</dict>
+		<key>9C705833-7A87-43F9-8C8F-2485909F2D6A</key>
+		<dict>
+			<key>xpos</key>
+			<real>255</real>
+			<key>ypos</key>
+			<real>485</real>
 		</dict>
 		<key>C4564BA3-C023-400E-AA4E-726CC734C91D</key>
 		<dict>
@@ -434,7 +513,7 @@ Thanks!</string>
 	<key>variablesdontexport</key>
 	<array/>
 	<key>version</key>
-	<string>0.5.3-alfred5</string>
+	<string>0.6-alfred5</string>
 	<key>webaddress</key>
 	<string>https://github.com/wrjlewis/notion-search-alfred5-workflow/</string>
 </dict>

--- a/notion.py
+++ b/notion.py
@@ -317,7 +317,9 @@ else:
                     else:
                         if searchResults.recordMap.get('block').get(searchResultObject.id).get('value').get('type') == "collection_view":
                             collectionPointerId = searchResults.recordMap.get('block').get(searchResultObject.id).get('value').get('format').get('collection_pointer').get('id')
-                            searchResultObject.icon = geticonpath(searchResultObject.id, searchResults.recordMap.get('collection').get(collectionPointerId).get('value').get('icon'))
+                            iconUrl = searchResults.recordMap.get('collection').get(collectionPointerId).get('value').get('icon')
+                            if iconUrl is not None:
+                                searchResultObject.icon = geticonpath(searchResultObject.id, searchResults.recordMap.get('collection').get(collectionPointerId).get('value').get('icon'))
                 else:
                     searchResultObject.icon = None
                     searchResultObject.title = searchResultObject.title


### PR DESCRIPTION
* Type ‘nsn’ for the option to quickly open a new page in Notion. Very handy! (Only supports the web app currently)

* https://github.com/wrjlewis/notion-search-alfred-workflow/issues/83 - Fixed a bug that would cause an error and no more results to be displayed, relating to new Notion projects and icons.

* Update readme with:
** new notion page functionality (only supports web app)
** new cairo instructions for those on apple silicon, use at your own risk but they work for me and svg icons now appear in search results.