### PR TITLE
Fix: Resolve 'Payload' object has no attribute 'pages' error

### DIFF
--- a/notion.py
+++ b/notion.py
@@ -258,7 +258,15 @@ if not (alfredQuery and alfredQuery.strip()):
 
             # Extract search results from notion recent page visits response
             searchResults = Payload(data)
-            for x in searchResults.pages:
+            # To support older versions of the payload
+            if hasattr(searchResults, 'pages') and isinstance(searchResults.pages, list):
+                results = searchResults.pages
+            elif hasattr(searchResults, 'results') and isinstance(searchResults.results, list):
+                results = searchResults.results
+            else:
+                results = []
+
+            for x in results:
                 searchResultObject = SearchResult(x.get('id'))
                 searchResultObject.title = x.get('name')
                 searchResultObject.subtitle = createSubtitleChain(searchResults.recordMap, searchResultObject.id)


### PR DESCRIPTION
### Summary
This PR fixes an issue where the `'Payload' object has no attribute 'pages'` error appears when using the Notion Alfred workflow. The error occurs due to changes in the Notion API response structure, where `pages` may no longer be present as an attribute. This fix checks for both `pages` and `results` attributes to ensure compatibility across different API versions.

### Changes
- Modified the code to check if the `Payload` object has either `pages` or `results` attributes.
- Updated the logic to use `results` if `pages` is not found, allowing the workflow to adapt to changes in the Notion API response.

### Related Issue
Fixes #16

### Additional Context
This solution ensures backward compatibility for users on older versions of the API, while also supporting recent updates. This should prevent future errors related to attribute mismatches in the payload object.